### PR TITLE
idp: use access_denied if user is not authorized for audience

### DIFF
--- a/pkg/idp/steps.go
+++ b/pkg/idp/steps.go
@@ -152,7 +152,7 @@ func (s *steps) VerifyAudience(ctx context.Context, audienceURL, clientID, userI
 	err = s.checkUser(ctx, audience, userID)
 	if errors.Is(err, hubauth.ErrUnauthorizedUser) {
 		return &hubauth.OAuthError{
-			Code:        "invalid_grant",
+			Code:        "access_denied",
 			Description: "user is not authorized for access",
 		}
 	}


### PR DESCRIPTION
This ensures that `invalid_grant` is only returned for errors that can be resolved by re-running the auth flow.