### PR TITLE
add interstitial for localhost redirects

### DIFF
--- a/pkg/httpapi/http.go
+++ b/pkg/httpapi/http.go
@@ -267,10 +267,14 @@ func (a *api) AuthorizeCode(w http.ResponseWriter, req *http.Request) {
 	})
 	w.Header().Set("Referrer-Policy", "no-referrer")
 
-	if res.DisplayCode != "" {
+	if res.DisplayCode != "" || res.Interstitial {
 		w.Header().Set("Content-Type", "text/html; charset=utf8")
 		w.Header().Set("Content-Security-Policy", "default-src 'none'; script-src 'unsafe-inline'; frame-ancestors 'none'")
-		codeDisplayHTML(res.DisplayCode, w)
+		if res.Interstitial {
+			redirectInterstitialHTML(res.URL, w)
+		} else {
+			codeDisplayHTML(res.DisplayCode, w)
+		}
 		return
 	}
 

--- a/pkg/httpapi/redirect_interstitial.go
+++ b/pkg/httpapi/redirect_interstitial.go
@@ -1,0 +1,23 @@
+package httpapi
+
+import (
+	"html/template"
+	"io"
+)
+
+var redirectInterstitialHTMLTemplate = template.Must(template.New("page").Parse(`<!doctype html>
+<html>
+<head>
+<title>Flynn Hub Auth</title>
+</head>
+<body>
+<h1>Flynn Auth</h1>
+<p>An application running on your computer would like access to Flynn credentials. You should only allow this request if you initiated it.</p>
+<br>
+<button onclick="window.location.href='{{.}}'">Allow Access</button>
+</body>
+</html>`))
+
+func redirectInterstitialHTML(url string, out io.Writer) error {
+	return redirectInterstitialHTMLTemplate.Execute(out, url)
+}

--- a/pkg/hubauth/idp.go
+++ b/pkg/hubauth/idp.go
@@ -32,7 +32,8 @@ type AuthorizeResponse struct {
 	URL     string
 	RPState string
 
-	DisplayCode string
+	Interstitial bool
+	DisplayCode  string
 }
 
 type ExchangeCodeRequest struct {

--- a/pkg/idp/oauth.go
+++ b/pkg/idp/oauth.go
@@ -234,7 +234,7 @@ func (s *idpService) AuthorizeCodeRedirect(ctx context.Context, req *hubauth.Aut
 	if req.RedirectURI == oobRedirectURI {
 		return &hubauth.AuthorizeResponse{DisplayCode: codeRes}, nil
 	}
-	dest := hubauth.RedirectURI(req.RedirectURI, req.ResponseMode == hubauth.ResponseModeFragment, map[string]string{
+	dest, isLocalhost := hubauth.RedirectURI(req.RedirectURI, req.ResponseMode == hubauth.ResponseModeFragment, map[string]string{
 		"code":  codeRes,
 		"state": req.ClientState,
 	})
@@ -242,7 +242,10 @@ func (s *idpService) AuthorizeCodeRedirect(ctx context.Context, req *hubauth.Aut
 		return nil, fmt.Errorf("idp: error parsing redirect URI %q", req.RedirectURI)
 	}
 
-	return &hubauth.AuthorizeResponse{URL: dest}, nil
+	return &hubauth.AuthorizeResponse{
+		URL:          dest,
+		Interstitial: isLocalhost,
+	}, nil
 }
 
 func (s *idpService) ExchangeCode(parentCtx context.Context, req *hubauth.ExchangeCodeRequest) (*hubauth.AccessToken, error) {

--- a/pkg/idp/oauth_test.go
+++ b/pkg/idp/oauth_test.go
@@ -310,6 +310,7 @@ func TestAuthorizeCodeRedirect(t *testing.T) {
 				require.Empty(t, resp.DisplayCode)
 				require.Empty(t, resp.RPState)
 				require.Contains(t, resp.URL, redirectURI)
+				require.False(t, resp.Interstitial)
 
 				u, err := url.Parse(resp.URL)
 				require.NoError(t, err)
@@ -329,6 +330,7 @@ func TestAuthorizeCodeRedirect(t *testing.T) {
 				require.Empty(t, resp.DisplayCode)
 				require.Empty(t, resp.RPState)
 				require.Contains(t, resp.URL, redirectURI)
+				require.False(t, resp.Interstitial)
 
 				u, err := url.Parse(resp.URL)
 				require.NoError(t, err)
@@ -346,6 +348,43 @@ func TestAuthorizeCodeRedirect(t *testing.T) {
 				require.Empty(t, resp.RPState)
 				require.Empty(t, resp.URL)
 				require.Equal(t, signedCode, resp.DisplayCode)
+				require.False(t, resp.Interstitial)
+			},
+		},
+		{
+			Desc:         "returns Interstitial when redirectURI is localhost",
+			RedirectURI:  "http://localhost:8080/",
+			ResponseMode: hubauth.ResponseModeQuery,
+			ValidateResponse: func(t *testing.T, resp *hubauth.AuthorizeResponse, err error) {
+				require.NoError(t, err)
+				require.Empty(t, resp.DisplayCode)
+				require.Empty(t, resp.RPState)
+				require.Contains(t, resp.URL, "http://localhost:8080/")
+				require.True(t, resp.Interstitial)
+
+				u, err := url.Parse(resp.URL)
+				require.NoError(t, err)
+
+				require.Equal(t, clientState, u.Query().Get("state"))
+				require.Equal(t, signedCode, u.Query().Get("code"))
+			},
+		},
+		{
+			Desc:         "returns Interstitial when redirectURI is 127.0.0.1",
+			RedirectURI:  "http://127.0.0.1/",
+			ResponseMode: hubauth.ResponseModeQuery,
+			ValidateResponse: func(t *testing.T, resp *hubauth.AuthorizeResponse, err error) {
+				require.NoError(t, err)
+				require.Empty(t, resp.DisplayCode)
+				require.Empty(t, resp.RPState)
+				require.Contains(t, resp.URL, "http://127.0.0.1/")
+				require.True(t, resp.Interstitial)
+
+				u, err := url.Parse(resp.URL)
+				require.NoError(t, err)
+
+				require.Equal(t, clientState, u.Query().Get("state"))
+				require.Equal(t, signedCode, u.Query().Get("code"))
 			},
 		},
 	}


### PR DESCRIPTION
This ensures that malicious programs that are partially sandboxed cannot get credentials. By "partially sandboxed" I mean the software can listen on localhost and open a URL, but not read our token cache from the home directory or manipulate the browser to click the button or access the page content.