### PR TITLE
datastore: fix audience created with no group returning one group when fetched from db

### DIFF
--- a/pkg/datastore/audience.go
+++ b/pkg/datastore/audience.go
@@ -55,10 +55,15 @@ type googleUserPolicy struct {
 func (c *audience) Export() *hubauth.Audience {
 	policies := make([]*hubauth.GoogleUserPolicy, len(c.Policies))
 	for i, p := range c.Policies {
+		var grps []string
+		if p.Groups != "" {
+			grps = strings.Split(p.Groups, ",")
+		}
+
 		policies[i] = &hubauth.GoogleUserPolicy{
 			Domain:  p.Domain,
 			APIUser: p.APIUser,
-			Groups:  strings.Split(p.Groups, ","),
+			Groups:  grps,
 		}
 	}
 	return &hubauth.Audience{

--- a/pkg/datastore/audience_test.go
+++ b/pkg/datastore/audience_test.go
@@ -55,6 +55,32 @@ func TestAudienceCRD(t *testing.T) {
 	_, err = s.GetAudience(ctx, a.URL)
 	require.Truef(t, errors.Is(err, hubauth.ErrNotFound), "wrong err %v", err)
 }
+
+func TestAudienceEmptyGroups(t *testing.T) {
+	s := newTestService(t)
+	ctx := context.Background()
+
+	a := &hubauth.Audience{
+		URL:       "https://controller.nogrp.example.com",
+		Name:      "Test Cluster",
+		Type:      "flynn_controller",
+		ClientIDs: []string{"a"},
+		Policies: []*hubauth.GoogleUserPolicy{
+			{
+				Domain:  "example.com",
+				APIUser: "user@example.com",
+				Groups:  []string{},
+			},
+		},
+	}
+	err := s.CreateAudience(ctx, a)
+	require.NoError(t, err)
+
+	got, err := s.GetAudience(ctx, a.URL)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(got.Policies[0].Groups))
+}
+
 func TestAudienceListForClientID(t *testing.T) {
 	s := newTestService(t)
 	ctx := context.Background()


### PR DESCRIPTION
when an audience with empty groups string is fetched from db, `Split` convert it to `[]string{""}` instead of expected `[]string{}`