### PR TITLE
groupsync: fix nil map

### DIFF
--- a/pkg/groupsync/adminclient.go
+++ b/pkg/groupsync/adminclient.go
@@ -36,7 +36,8 @@ var _ adminClientFactory = (*googleAdminClientFactory)(nil)
 
 func newAdminClientFactory() adminClientFactory {
 	return &googleAdminClientFactory{
-		tokenSource: google.ComputeTokenSource("", "https://www.googleapis.com/auth/iam"),
+		tokenSource:  google.ComputeTokenSource("", "https://www.googleapis.com/auth/iam"),
+		adminClients: make(map[string]adminClient),
 	}
 }
 


### PR DESCRIPTION
Fixes this error in production:

```
assignment to entry in nil map
at github.com/flynn/hubauth/pkg/groupsync.(*googleAdminClientFactory).NewAdminClient (adminclient.go:66)
at github.com/flynn/hubauth/pkg/groupsync.(*Service).Sync.func1 (groupsync.go:90)
at github.com/flynn/hubauth/pkg/groupsync.(*Service).Sync (groupsync.go:150)
at main.main.func1.1 (main.go:53)
at golang.org/x/sync/errgroup.(*Group).Go.func1 (errgroup.go:57)
```