### PR TITLE
idp: Add refresh_token_issue_time to token responses

### DIFF
--- a/pkg/httpapi/http_test.go
+++ b/pkg/httpapi/http_test.go
@@ -460,6 +460,7 @@ func TestTokenAuthorizationCode(t *testing.T) {
 		Nonce:                 "nonce",
 		Audience:              exchangeReq.Audience,
 		RefreshTokenExpiresIn: 120,
+		RefreshTokenIssueTime: now,
 		RedirectURI:           exchangeReq.RedirectURI,
 	}
 
@@ -492,6 +493,11 @@ func TestTokenAuthorizationCode(t *testing.T) {
 	require.NoError(t, json.NewDecoder(r.Body).Decode(got))
 	r.Body.Close()
 
+	// require.Equal doesn't work with timestamps that have been deserialized
+	require.WithinDuration(t, want.RefreshTokenIssueTime, got.RefreshTokenIssueTime, 0)
+	want.RefreshTokenIssueTime = time.Time{}
+	got.RefreshTokenIssueTime = time.Time{}
+
 	require.Equal(t, &want, got)
 }
 
@@ -520,6 +526,7 @@ func TestTokenRefreshToken(t *testing.T) {
 		Nonce:                 "nonce",
 		Audience:              refreshReq.Audience,
 		RefreshTokenExpiresIn: 120,
+		RefreshTokenIssueTime: now,
 		RedirectURI:           redirectURLFull,
 	}
 
@@ -549,6 +556,11 @@ func TestTokenRefreshToken(t *testing.T) {
 	got := new(hubauth.AccessToken)
 	require.NoError(t, json.NewDecoder(r.Body).Decode(got))
 	r.Body.Close()
+
+	// require.Equal doesn't work with timestamps that have been deserialized
+	require.WithinDuration(t, want.RefreshTokenIssueTime, got.RefreshTokenIssueTime, 0)
+	want.RefreshTokenIssueTime = time.Time{}
+	got.RefreshTokenIssueTime = time.Time{}
 
 	require.Equal(t, &want, got)
 }

--- a/pkg/hubauth/idp.go
+++ b/pkg/hubauth/idp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/url"
+	"time"
 )
 
 var ErrUnauthorizedUser = errors.New("hubauth: unauthorized user")
@@ -52,7 +53,8 @@ type AccessToken struct {
 	Nonce        string `json:"nonce,omitempty"`
 	Audience     string `json:"audience,omitempty"`
 
-	RefreshTokenExpiresIn int `json:"refresh_token_expires_in"`
+	RefreshTokenExpiresIn int       `json:"refresh_token_expires_in"`
+	RefreshTokenIssueTime time.Time `json:"refresh_token_issue_time"`
 
 	// used by HTTP layer to set Access-Control-Allow-Origin
 	RedirectURI string `json:"-"`

--- a/pkg/idp/oauth.go
+++ b/pkg/idp/oauth.go
@@ -345,6 +345,7 @@ func (s *idpService) ExchangeCode(parentCtx context.Context, req *hubauth.Exchan
 		RedirectURI:           req.RedirectURI,
 		Audience:              req.Audience,
 		RefreshTokenExpiresIn: int(client.RefreshTokenExpiry / time.Second),
+		RefreshTokenIssueTime: now,
 	}
 	if res.AccessToken == "" {
 		// if no audience was provided, provide a refresh token that can be used to to access /audiences
@@ -417,6 +418,7 @@ func (s *idpService) RefreshToken(ctx context.Context, req *hubauth.RefreshToken
 		RedirectURI:           newToken.RedirectURI,
 		Audience:              req.Audience,
 		RefreshTokenExpiresIn: int(time.Until(newToken.ExpiryTime) / time.Second),
+		RefreshTokenIssueTime: now,
 	}
 	if res.AccessToken == "" {
 		// if no audience was provided, provide a refresh token that can be used to access /audiences

--- a/pkg/idp/oauth_test.go
+++ b/pkg/idp/oauth_test.go
@@ -580,6 +580,7 @@ func TestExchangeCode(t *testing.T) {
 	refreshToken := "refreshToken"
 	accessToken := "accessToken"
 	refreshTokenExpiry := time.Second * 42
+	now := time.Now()
 
 	testCases := []struct {
 		Desc        string
@@ -597,6 +598,7 @@ func TestExchangeCode(t *testing.T) {
 				Nonce:                 nonce,
 				Audience:              audienceURL,
 				RefreshTokenExpiresIn: int(refreshTokenExpiry / time.Second),
+				RefreshTokenIssueTime: now,
 				RedirectURI:           redirectURI,
 			},
 		},
@@ -611,6 +613,7 @@ func TestExchangeCode(t *testing.T) {
 				Nonce:                 nonce,
 				Audience:              "",
 				RefreshTokenExpiresIn: int(refreshTokenExpiry / time.Second),
+				RefreshTokenIssueTime: now,
 				RedirectURI:           redirectURI,
 			},
 		},
@@ -622,7 +625,6 @@ func TestExchangeCode(t *testing.T) {
 			idpService := newTestIdPService(t)
 
 			ctx := hubauth.InitClientInfo(context.Background())
-			now := time.Now()
 
 			expireTime, _ := ptypes.TimestampProto(now.Add(codeExpiry))
 			signedCode, err := hmacpb.SignMarshal(idpService.codeKey, &pb.Code{
@@ -859,6 +861,7 @@ func TestRefreshToken(t *testing.T) {
 				ExpiresIn:             int(accessTokenDuration / time.Second),
 				Audience:              audienceURL,
 				RefreshTokenExpiresIn: int(time.Until(issueTime.Add(refreshTokenExpire)) / time.Second),
+				RefreshTokenIssueTime: now,
 				RedirectURI:           redirectURI,
 			},
 		},
@@ -872,6 +875,7 @@ func TestRefreshToken(t *testing.T) {
 				ExpiresIn:             int(time.Until(issueTime.Add(refreshTokenExpire)) / time.Second),
 				Audience:              "",
 				RefreshTokenExpiresIn: int(time.Until(issueTime.Add(refreshTokenExpire)) / time.Second),
+				RefreshTokenIssueTime: now,
 				RedirectURI:           redirectURI,
 			},
 		},


### PR DESCRIPTION
This allows clients to prevent races when persisting refresh tokens.