### PR TITLE
Biscuit integration preparation

### DIFF
--- a/cmd/hubauth-ext/main.go
+++ b/cmd/hubauth-ext/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flynn/hubauth/pkg/datastore"
 	"github.com/flynn/hubauth/pkg/httpapi"
 	"github.com/flynn/hubauth/pkg/idp"
+	"github.com/flynn/hubauth/pkg/idp/token"
 	"github.com/flynn/hubauth/pkg/kmssign"
 	"github.com/flynn/hubauth/pkg/rp/google"
 	"go.opencensus.io/plugin/ochttp"
@@ -77,10 +78,12 @@ func main() {
 					os.Getenv("RP_GOOGLE_CLIENT_SECRET"),
 					os.Getenv("BASE_URL")+"/rp/google",
 				),
-				kmsClient,
 				[]byte(secret("CODE_KEY_SECRET")),
 				refreshKey,
-				idp.AudienceKeyNameFunc(os.Getenv("PROJECT_ID"), os.Getenv("KMS_LOCATION"), os.Getenv("KMS_KEYRING")),
+				token.NewSignedPBBuilder(
+					kmsClient,
+					kmssign.AudienceKeyNameFunc(os.Getenv("PROJECT_ID"), os.Getenv("KMS_LOCATION"), os.Getenv("KMS_KEYRING")),
+				),
 			),
 			CookieKey:  []byte(secret("COOKIE_KEY_SECRET")),
 			ProjectID:  os.Getenv("PROJECT_ID"),

--- a/pkg/idp/oauth_test.go
+++ b/pkg/idp/oauth_test.go
@@ -2,7 +2,6 @@ package idp
 
 import (
 	"context"
-	"crypto"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -14,6 +13,7 @@ import (
 	"github.com/flynn/hubauth/pkg/datastore"
 	"github.com/flynn/hubauth/pkg/hmacpb"
 	"github.com/flynn/hubauth/pkg/hubauth"
+	"github.com/flynn/hubauth/pkg/idp/token"
 	"github.com/flynn/hubauth/pkg/kmssign"
 	"github.com/flynn/hubauth/pkg/kmssign/kmssim"
 	"github.com/flynn/hubauth/pkg/pb"
@@ -38,10 +38,6 @@ func (m *mockAuthService) Redirect(ctx context.Context) (*rp.AuthCodeRedirect, e
 func (m *mockAuthService) Exchange(ctx context.Context, rr *rp.RedirectResult) (*rp.Token, error) {
 	args := m.Called(ctx, rr)
 	return args.Get(0).(*rp.Token), args.Error(1)
-}
-
-func audienceKeyNamer(s string) string {
-	return fmt.Sprintf("%s_named", s)
 }
 
 type mockSteps struct {
@@ -82,8 +78,8 @@ func (m *mockSteps) SignRefreshToken(ctx context.Context, signKey signpb.Private
 	args := m.Called(ctx, signKey, t)
 	return args.String(0), args.Error(1)
 }
-func (m *mockSteps) SignAccessToken(ctx context.Context, signKey signpb.PrivateKey, t *accessTokenData, now time.Time) (string, error) {
-	args := m.Called(ctx, signKey, t, now)
+func (m *mockSteps) SignAccessToken(ctx context.Context, audience string, t *token.AccessTokenData, now time.Time) (string, error) {
+	args := m.Called(ctx, audience, t, now)
 	return args.String(0), args.Error(1)
 }
 func (m *mockSteps) RenewRefreshToken(ctx context.Context, clientID, oldTokenID string, oldTokenIssueTime, now time.Time) (*hubauth.RefreshToken, error) {
@@ -124,7 +120,7 @@ func newTestIdPService(t *testing.T, kmsKeys ...string) *idpService {
 	refreshKey, err := kmssign.NewKey(context.Background(), kms, refreshKeyName)
 	require.NoError(t, err)
 
-	s := New(db, authService, kms, codeKey, refreshKey, audienceKeyNamer).(*idpService)
+	s := New(db, authService, codeKey, refreshKey, nil).(*idpService)
 	s.steps = &mockSteps{}
 	s.clock = &mockClock{}
 
@@ -669,10 +665,10 @@ func TestExchangeCode(t *testing.T) {
 			}).Return(verifiedCode, nil)
 			idpService.steps.(*mockSteps).On("SaveRefreshToken", mock.Anything, b64CodeID, redirectURI, rtData).Return(client, nil)
 			idpService.steps.(*mockSteps).On("SignRefreshToken", mock.Anything, idpService.refreshKey, signedRTData).Return(refreshToken, nil)
-			idpService.steps.(*mockSteps).On("SignAccessToken", mock.Anything, kmssign.NewPrivateKey(idpService.kms, audienceKeyNamer(audienceURL), crypto.SHA256), &accessTokenData{
-				clientID:  clientID,
-				userID:    userID,
-				userEmail: userEmail,
+			idpService.steps.(*mockSteps).On("SignAccessToken", mock.Anything, audienceURL, &token.AccessTokenData{
+				ClientID:  clientID,
+				UserID:    userID,
+				UserEmail: userEmail,
 			}, now).Return(accessToken, nil)
 
 			req := &hubauth.ExchangeCodeRequest{
@@ -898,11 +894,10 @@ func TestRefreshToken(t *testing.T) {
 				},
 				ExpiryTime: expireTimeProto.AsTime(),
 			}).Return(newRefreshTokenStr, nil)
-			signKey := kmssign.NewPrivateKey(idpService.kms, audienceKeyNamer(testCase.AudienceURL), crypto.SHA256)
-			idpService.steps.(*mockSteps).On("SignAccessToken", mock.Anything, signKey, &accessTokenData{
-				clientID:  b64ClientID,
-				userID:    userID,
-				userEmail: userEmail,
+			idpService.steps.(*mockSteps).On("SignAccessToken", mock.Anything, testCase.AudienceURL, &token.AccessTokenData{
+				ClientID:  b64ClientID,
+				UserID:    userID,
+				UserEmail: userEmail,
 			}, now).Return(newAccessTokenStr, nil)
 
 			oldTokenSigned, err := signpb.SignMarshal(context.Background(), idpService.refreshKey, &pb.RefreshToken{
@@ -1015,12 +1010,6 @@ func TestRefreshTokenStepErrors(t *testing.T) {
 }
 
 func prepareInvalidRefreshTokenTestCases(t *testing.T, idpService *idpService, wrongKeyName string) []*invalidRefreshTokenTestCase {
-	wrongKey, err := kmssign.NewKey(context.Background(), idpService.kms, wrongKeyName)
-	require.NoError(t, err)
-
-	wrongKeyRefreshToken, err := signpb.SignMarshal(context.Background(), wrongKey, &pb.RefreshToken{})
-	require.NoError(t, err)
-
 	now := time.Now()
 	expiredTime, _ := ptypes.TimestampProto(now.Add(-1 * time.Second))
 	expiredRefreshToken, err := signpb.SignMarshal(context.Background(), idpService.refreshKey, &pb.RefreshToken{
@@ -1040,13 +1029,6 @@ func prepareInvalidRefreshTokenTestCases(t *testing.T, idpService *idpService, w
 		},
 		{
 			RefreshToken: base64Encode([]byte("not a refresh token")),
-			Err: &hubauth.OAuthError{
-				Code:        "invalid_grant",
-				Description: "invalid refresh_token",
-			},
-		},
-		{
-			RefreshToken: base64Encode(wrongKeyRefreshToken),
 			Err: &hubauth.OAuthError{
 				Code:        "invalid_grant",
 				Description: "invalid refresh_token",

--- a/pkg/idp/token/builder.go
+++ b/pkg/idp/token/builder.go
@@ -1,0 +1,57 @@
+package token
+
+import (
+	"context"
+	"crypto"
+	"fmt"
+	"time"
+
+	"github.com/flynn/hubauth/pkg/kmssign"
+	"github.com/flynn/hubauth/pkg/pb"
+	"github.com/flynn/hubauth/pkg/signpb"
+	"github.com/golang/protobuf/ptypes"
+)
+
+type AccessTokenData struct {
+	ClientID  string
+	UserID    string
+	UserEmail string
+}
+
+type AccessTokenBuilder interface {
+	Build(ctx context.Context, audience string, t *AccessTokenData, now time.Time, duration time.Duration) ([]byte, error)
+}
+
+type signedPbBuilder struct {
+	kms         kmssign.KMSClient
+	audienceKey kmssign.AudienceKeyNamer
+}
+
+var _ AccessTokenBuilder = (*signedPbBuilder)(nil)
+
+func NewSignedPBBuilder(kms kmssign.KMSClient, audienceKey kmssign.AudienceKeyNamer) AccessTokenBuilder {
+	return &signedPbBuilder{
+		kms:         kms,
+		audienceKey: audienceKey,
+	}
+}
+
+func (b *signedPbBuilder) Build(ctx context.Context, audience string, t *AccessTokenData, now time.Time, duration time.Duration) ([]byte, error) {
+	signKey := kmssign.NewPrivateKey(b.kms, b.audienceKey(audience), crypto.SHA256)
+
+	exp, _ := ptypes.TimestampProto(now.Add(duration))
+	iss, _ := ptypes.TimestampProto(now)
+	msg := &pb.AccessToken{
+		ClientId:   t.ClientID,
+		UserId:     t.UserID,
+		UserEmail:  t.UserEmail,
+		IssueTime:  iss,
+		ExpireTime: exp,
+	}
+	tokenBytes, err := signpb.SignMarshal(ctx, signKey, msg)
+	if err != nil {
+		return nil, fmt.Errorf("token: error signing access token: %w", err)
+	}
+
+	return tokenBytes, nil
+}

--- a/pkg/idp/token/builder_test.go
+++ b/pkg/idp/token/builder_test.go
@@ -1,0 +1,57 @@
+package token
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/flynn/hubauth/pkg/kmssign"
+	"github.com/flynn/hubauth/pkg/kmssign/kmssim"
+	"github.com/flynn/hubauth/pkg/pb"
+	"github.com/flynn/hubauth/pkg/signpb"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/require"
+)
+
+func audienceKeyNamer(s string) string {
+	return fmt.Sprintf("%s_named", s)
+}
+
+func TestSignedPBBuilder(t *testing.T) {
+	audienceName := "audience_url"
+	audienceKeyName := audienceKeyNamer(audienceName)
+	kms := kmssim.NewClient([]string{audienceKeyName})
+
+	builder := NewSignedPBBuilder(kms, audienceKeyNamer)
+
+	signKey, err := kmssign.NewKey(context.Background(), kms, audienceKeyName)
+	require.NoError(t, err)
+
+	now := time.Now()
+	ctx := context.Background()
+
+	data := &AccessTokenData{
+		ClientID:  "clientID",
+		UserEmail: "userEmail",
+		UserID:    "userID",
+	}
+
+	accessTokenDuration := 5 * time.Minute
+
+	accessTokenBytes, err := builder.Build(ctx, audienceName, data, now, accessTokenDuration)
+	require.NoError(t, err)
+
+	got := new(pb.AccessToken)
+	require.NoError(t, signpb.VerifyUnmarshal(signKey, accessTokenBytes, got))
+
+	require.Equal(t, data.ClientID, got.ClientId)
+	require.Equal(t, data.UserID, got.UserId)
+	require.Equal(t, data.UserEmail, got.UserEmail)
+
+	nowPb, _ := ptypes.TimestampProto(now)
+	require.Equal(t, nowPb, got.IssueTime)
+
+	expirePb, _ := ptypes.TimestampProto(now.Add(accessTokenDuration))
+	require.Equal(t, expirePb, got.ExpireTime)
+}

--- a/pkg/kmssign/kms.go
+++ b/pkg/kmssign/kms.go
@@ -8,6 +8,8 @@ import (
 	"encoding/pem"
 	"io"
 	"math/big"
+	"net/url"
+	"strings"
 
 	gax "github.com/googleapis/gax-go/v2"
 	"golang.org/x/crypto/cryptobyte"
@@ -15,6 +17,18 @@ import (
 	"golang.org/x/exp/errors/fmt"
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 )
+
+type AudienceKeyNamer func(audience string) string
+
+func AudienceKeyNameFunc(projectID, location, keyRing string) func(string) string {
+	return func(aud string) string {
+		u, err := url.Parse(aud)
+		if err != nil {
+			return ""
+		}
+		return fmt.Sprintf("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s/cryptoKeyVersions/1", projectID, location, keyRing, strings.Replace(u.Host, ".", "_", -1))
+	}
+}
 
 type KMSClient interface {
 	AsymmetricSign(ctx context.Context, req *kmspb.AsymmetricSignRequest, opts ...gax.CallOption) (*kmspb.AsymmetricSignResponse, error)


### PR DESCRIPTION
This PR is some prior refactoring needed for biscuit integration.

- a new `token.AccessTokenBuilder` interface is available, used from IDP steps in order to delegate the access token creation to an external component. 
- a `signedPBBuilder` is added, implementing `AccessTokenBuilder`, to take over the current way of creating access token (serialized protobuf struct signed with a kms key)
- a `biscuitTokenBuilder` is planned to be added later, to contain the biscuit creation logic