### PR TITLE
cli: improve output of audience list-policies

### DIFF
--- a/pkg/cli/audiences.go
+++ b/pkg/cli/audiences.go
@@ -135,9 +135,9 @@ func (c *audiencesListPoliciesCmd) Run(cfg *Config) error {
 
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
-	t.AppendHeader(table.Row{"APIUser", "Domain", "Groups"})
+	t.AppendHeader(table.Row{"Domain", "APIUser", "Groups"})
 	for _, p := range audience.Policies {
-		t.AppendRow(table.Row{p.APIUser, p.Domain, p.Groups})
+		t.AppendRow(table.Row{p.Domain, p.APIUser, p.Groups})
 	}
 	t.Render()
 	return nil

--- a/pkg/cli/audiences_test.go
+++ b/pkg/cli/audiences_test.go
@@ -505,9 +505,9 @@ func TestAudienceListPolicies(t *testing.T) {
 	expectedBuf := new(bytes.Buffer)
 	tw := table.NewWriter()
 	tw.SetOutputMirror(expectedBuf)
-	tw.AppendHeader(table.Row{"APIUser", "Domain", "Groups"})
+	tw.AppendHeader(table.Row{"Domain", "APIUser", "Groups"})
 	for _, p := range audience.Policies {
-		tw.AppendRow(table.Row{p.APIUser, p.Domain, p.Groups})
+		tw.AppendRow(table.Row{p.Domain, p.APIUser, p.Groups})
 	}
 	tw.Render()
 


### PR DESCRIPTION
moved domain to be the first column of the table as it represent the policy identifier